### PR TITLE
chore: compose.yml Redis healthcheck 변경

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -7,8 +7,6 @@ services:
     volumes:
       - ./client/build:/usr/share/nginx/html:ro
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
-    depends_on:
-      - backend
 
   db:
     image: mariadb
@@ -32,7 +30,7 @@ services:
     image: redis
     restart: always
     healthcheck:
-      test: ["CMD-SHELL", "redis-cli -a $$(sed 's/requirepass //' /run/secrets/redis) ping | grep PONG"]
+      test: ["CMD-SHELL", "redis-cli -a $$(grep requirepass /run/secrets/redis | sed 's/requirepass //') ping | grep PONG"]
       interval: 3s
       retries: 5
     ports:


### PR DESCRIPTION
redis.conf에 여러 줄의 설정을 사용하는 경우를 대비하여 healthcheck 방식을 약간 변경했습니다.

추가로 불필요한 dependancy도 삭제했습니다.