### PR TITLE
feat : AOP 를 이용한 Logging 구현 (아래 패키지 내 클래스의 모든 메소드에 적용)

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.14'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	compileOnly 'org.projectlombok:lombok'
 	compileOnly 'org.apache.httpcomponents:httpclient:4.5.14'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/server/src/main/java/seb4141preproject/security/auth/filter/JwtAuthenticationFilter.java
+++ b/server/src/main/java/seb4141preproject/security/auth/filter/JwtAuthenticationFilter.java
@@ -27,8 +27,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         String accessToken = resolveAccessToken(request); // request header 에서 accessToken 추출
 
-        log.info("Authentication Filter validateToken 실행");
-
         if (jwtTokenizer.validateToken(accessToken)) {
             Authentication authentication = jwtTokenizer.getAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -43,8 +41,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         String method = request.getMethod(); // request 의 메소드 종류
         String[] urls = new String[] {"/api/members", "/api/auths/login", "/h2.*"}; // 회원가입, 로그인, h2는 토큰이 필요 없음
 
+        log.info("======= method name : {} =======", "shouldNotFilter");
+
+        log.info("method : " + method);
         log.info("path : " + path);
-        log.info("match ? : " + Arrays.stream(urls).anyMatch(s -> path.matches(s)));
+        log.info("match : " + Arrays.stream(urls).anyMatch(s -> path.matches(s)));
 
         return Arrays.stream(urls).anyMatch(s -> path.matches(s))
                 || (method.equals("GET") && !path.matches(".*/me|/api/members/.*"));

--- a/server/src/main/java/seb4141preproject/security/auth/filter/JwtExceptionHandlerFilter.java
+++ b/server/src/main/java/seb4141preproject/security/auth/filter/JwtExceptionHandlerFilter.java
@@ -38,8 +38,6 @@ public class JwtExceptionHandlerFilter extends OncePerRequestFilter {
         try {
             filterChain.doFilter(request, response);
 
-            log.info("Exception Filter filterChain 실행");
-
         } catch (io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
             log.error("잘못된 Access Token 서명입니다.", e);
             ErrorResponder.sendJwtErrorResponse(response, e.getMessage());

--- a/server/src/main/java/seb4141preproject/utils/SimpleLoggingAop.java
+++ b/server/src/main/java/seb4141preproject/utils/SimpleLoggingAop.java
@@ -1,0 +1,60 @@
+package seb4141preproject.utils;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Aspect
+@Component
+public class SimpleLoggingAop {
+
+    @Pointcut("execution(public * *(..))")
+    private void anyPublicOperation() {}
+
+    @Pointcut("within(seb4141preproject.answers.service..*)")
+    private void inAnswers() {}
+    @Pointcut("within(seb4141preproject.members.service..*)")
+    private void inMembers() {}
+    @Pointcut("within(seb4141preproject.questions.service..*)")
+    private void inQuestions() {}
+    @Pointcut("within(seb4141preproject.security.auth.service..*)")
+    private void inSecurity() {}
+
+    @Pointcut("anyPublicOperation() && ( inAnswers() || inMembers() || inQuestions() || inSecurity() )")
+    private void cut() {}
+
+    @Before("cut()")
+    public void beforeParameterLogging(JoinPoint joinPoint) {
+        Method method = getMethod(joinPoint);
+        log.info("======= method name : {} =======", method.getName());
+
+        Object[] args = joinPoint.getArgs();
+        if (args.length == 0) {
+            log.info("no parameter");
+        } else {
+            for (Object arg : args) {
+                log.info("parameter type : {}", arg.getClass().getSimpleName());
+                log.info("parameter value : {}", arg);
+            }
+        }
+    }
+
+    @AfterReturning(value = "cut()", returning = "returnObj")
+    public void afterReturnLogging(JoinPoint joinPoint, Object returnObj) {
+        Method method = getMethod(joinPoint);
+        log.info("======= method name : {} =======", method.getName());
+
+        log.info("return type : {}", returnObj.getClass().getSimpleName());
+        log.info("return value : {}", returnObj);
+    }
+
+    private Method getMethod(JoinPoint joinPoint) {
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        return signature.getMethod();
+    }
+}


### PR DESCRIPTION
1. answers - service
2. members - service
3. questions - service
4. security - auth - service

* 빌드파일 AOP dependency 추가
* service 단의 메소드 명, parameter type / value, return type / value 를 로깅
* parameter 및 return value는 json 형태로 가독성 좋게 로깅하려 했으나, 특정 메소드 (createQuestion) 에서의 stackoverflowerror 발생 및 LocalDateTime을 toJson 하려면 커스텀 설정이 추가로 필요해서 일단 Object 자체로 기록.

* JwtAuthenticationFilter.java의 shouldNotFilter 메소드는 Protected 형식이기 때문에 AOP가 적용 불가하여 자체 로깅 그대로 남겨놓음.